### PR TITLE
Update NotepadNext.git to 0.5.1

### DIFF
--- a/com.github.dail8859.NotepadNext.yml
+++ b/com.github.dail8859.NotepadNext.yml
@@ -9,10 +9,10 @@ command: NotepadNext
 
 finish-args:
     - --share=ipc
-    - --socket=x11
+    - --socket=wayland
+    - --socket=fallback-x11
     - --device=dri
     - --filesystem=home
-    - --env=QT_QPA_PLATFORM=xcb
 
 modules:
     - name: NotepadNext
@@ -30,5 +30,4 @@ modules:
       sources:
         - type: git
           url: https://github.com/dail8859/NotepadNext.git
-          tag: v0.5
-          commit: bd6ca110d8219bde7467866e0d67da53353c69c8
+          commit: 91949c7d6a62734713d44f35394031d05bbbf710

--- a/com.github.dail8859.NotepadNext.yml
+++ b/com.github.dail8859.NotepadNext.yml
@@ -30,4 +30,5 @@ modules:
       sources:
         - type: git
           url: https://github.com/dail8859/NotepadNext.git
-          commit: 283691cf5c62eedc4d591529adb3446cab4963db
+          tag: v0.5.1
+          commit: 9d19014e770b5c04c634e233f8d413ec631c1646

--- a/com.github.dail8859.NotepadNext.yml
+++ b/com.github.dail8859.NotepadNext.yml
@@ -30,4 +30,4 @@ modules:
       sources:
         - type: git
           url: https://github.com/dail8859/NotepadNext.git
-          commit: 91949c7d6a62734713d44f35394031d05bbbf710
+          commit: 283691cf5c62eedc4d591529adb3446cab4963db

--- a/com.github.dail8859.NotepadNext.yml
+++ b/com.github.dail8859.NotepadNext.yml
@@ -32,3 +32,6 @@ modules:
           url: https://github.com/dail8859/NotepadNext.git
           tag: v0.5.1
           commit: 9d19014e770b5c04c634e233f8d413ec631c1646
+          x-checker-data:
+            type: git
+            tag-pattern: ^v([\d.]+)$


### PR DESCRIPTION
This PR updates NotepadNext and adds adds flatpak-external-data-checker support for automatic update PRs (but manual merging process, for more info, check https://github.com/flathub/com.github.dail8859.NotepadNext/pull/4#issuecomment-1114097371.

Closes https://github.com/flathub/com.github.dail8859.NotepadNext/issues/2.
Closes https://github.com/flathub/com.github.dail8859.NotepadNext/issues/3.